### PR TITLE
feat: Phase 2 Collector 구현 - Jolokia HTTP 클라이언트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +96,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
 ]
 
 [[package]]
@@ -174,6 +201,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -214,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +267,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -276,6 +342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +365,92 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "difflib"
@@ -307,6 +468,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -331,6 +498,21 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -364,12 +546,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -377,6 +575,49 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -391,16 +632,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -411,7 +674,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -434,6 +697,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +718,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -498,6 +778,27 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http 0.2.12",
+ "infer",
+ "pin-project-lite",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
 ]
 
 [[package]]
@@ -700,16 +1001,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -794,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -823,6 +1159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +1179,18 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -876,12 +1234,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -933,6 +1328,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,7 +1432,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1012,6 +1468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,7 +1481,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1033,6 +1495,7 @@ dependencies = [
  "assert_cmd",
  "axum",
  "clap",
+ "criterion",
  "once_cell",
  "predicates",
  "reqwest",
@@ -1046,6 +1509,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]
@@ -1066,7 +1530,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1090,6 +1554,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1159,6 +1632,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -1353,6 +1837,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1593,6 +2087,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1623,6 +2118,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +2141,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1711,6 +2228,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-link"
@@ -1951,6 +2477,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiremock"
+version = "0.5.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a3a53eaf34f390dd30d7b1b078287dd05df2aa2e21a589ccb80f5c7253c2e9"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.7",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper 0.14.32",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +2525,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,12 @@ tokio-test = "0.4"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 assert_cmd = "2.0"
 predicates = "3.0"
+wiremock = "0.5"
+criterion = "0.5"
+
+[[bench]]
+name = "collector_bench"
+harness = false
 
 [profile.release]
 lto = true

--- a/benches/collector_bench.rs
+++ b/benches/collector_bench.rs
@@ -1,0 +1,68 @@
+//! Collector 벤치마크
+//!
+//! JSON 파싱 성능 측정
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rjmx_exporter::collector::parse_response;
+
+fn benchmark_parse_response(c: &mut Criterion) {
+    let simple_json = r#"{
+        "request": {"mbean": "java.lang:type=Threading", "type": "read"},
+        "value": 42,
+        "timestamp": 1609459200,
+        "status": 200
+    }"#;
+
+    let composite_json = r#"{
+        "request": {"mbean": "java.lang:type=Memory", "type": "read"},
+        "value": {
+            "init": 268435456,
+            "committed": 268435456,
+            "max": 4294967296,
+            "used": 52428800
+        },
+        "timestamp": 1609459200,
+        "status": 200
+    }"#;
+
+    let wildcard_json = r#"{
+        "request": {"mbean": "java.lang:type=GarbageCollector,name=*", "type": "read"},
+        "value": {
+            "java.lang:type=GarbageCollector,name=G1 Young Generation": {
+                "CollectionCount": 42,
+                "CollectionTime": 1234
+            },
+            "java.lang:type=GarbageCollector,name=G1 Old Generation": {
+                "CollectionCount": 5,
+                "CollectionTime": 567
+            }
+        },
+        "timestamp": 1609459200,
+        "status": 200
+    }"#;
+
+    let mut group = c.benchmark_group("parse_response");
+
+    group.bench_with_input(
+        BenchmarkId::new("simple", "number"),
+        &simple_json,
+        |b, json| b.iter(|| parse_response(json)),
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("composite", "memory"),
+        &composite_json,
+        |b, json| b.iter(|| parse_response(json)),
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("wildcard", "gc"),
+        &wildcard_json,
+        |b, json| b.iter(|| parse_response(json)),
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_parse_response);
+criterion_main!(benches);

--- a/src/collector/client.rs
+++ b/src/collector/client.rs
@@ -1,0 +1,339 @@
+//! Jolokia HTTP 클라이언트
+//!
+//! Connection pooling과 타임아웃을 지원하는 비동기 HTTP 클라이언트입니다.
+
+use reqwest::{Client, ClientBuilder};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tracing::{debug, instrument, warn};
+
+use super::parser::{parse_bulk_response, parse_response, CollectResult, JolokiaResponse};
+use crate::error::CollectorError;
+
+/// Jolokia HTTP 클라이언트
+#[derive(Clone)]
+pub struct JolokiaClient {
+    client: Client,
+    base_url: String,
+    #[allow(dead_code)]
+    default_timeout: Duration,
+    auth: Option<(String, String)>,
+}
+
+/// Jolokia 요청 구조체
+#[derive(Debug, Serialize)]
+struct JolokiaRequest {
+    #[serde(rename = "type")]
+    request_type: String,
+    mbean: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attribute: Option<AttributeSpec>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum AttributeSpec {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+/// 재시도 설정
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// 최대 재시도 횟수
+    pub max_retries: u32,
+    /// 초기 지연 시간
+    pub initial_delay: Duration,
+    /// 최대 지연 시간
+    pub max_delay: Duration,
+    /// 지연 시간 증가 배수
+    pub multiplier: f64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(2),
+            multiplier: 2.0,
+        }
+    }
+}
+
+impl JolokiaClient {
+    /// 새 클라이언트 생성
+    ///
+    /// # Arguments
+    /// * `base_url` - Jolokia 엔드포인트 URL (예: "http://localhost:8778/jolokia")
+    /// * `timeout_ms` - 기본 타임아웃 (밀리초)
+    ///
+    /// # Example
+    /// ```ignore
+    /// let client = JolokiaClient::new("http://localhost:8778/jolokia", 5000)?;
+    /// ```
+    pub fn new(base_url: &str, timeout_ms: u64) -> CollectResult<Self> {
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_millis(timeout_ms))
+            .pool_max_idle_per_host(10)
+            .pool_idle_timeout(Duration::from_secs(30))
+            .build()
+            .map_err(CollectorError::HttpClientInit)?;
+
+        Ok(Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            default_timeout: Duration::from_millis(timeout_ms),
+            auth: None,
+        })
+    }
+
+    /// Basic Auth 설정
+    pub fn with_auth(mut self, username: &str, password: &str) -> Self {
+        self.auth = Some((username.to_string(), password.to_string()));
+        self
+    }
+
+    /// 단일 MBean 조회
+    #[instrument(skip(self), fields(mbean = %mbean))]
+    pub async fn read_mbean(
+        &self,
+        mbean: &str,
+        attributes: Option<&[String]>,
+    ) -> CollectResult<JolokiaResponse> {
+        let request = JolokiaRequest {
+            request_type: "read".to_string(),
+            mbean: mbean.to_string(),
+            attribute: attributes.map(|attrs| {
+                if attrs.len() == 1 {
+                    AttributeSpec::Single(attrs[0].clone())
+                } else {
+                    AttributeSpec::Multiple(attrs.to_vec())
+                }
+            }),
+        };
+
+        debug!("Sending Jolokia read request");
+
+        let mut req = self.client.post(&self.base_url).json(&request);
+
+        if let Some((username, password)) = &self.auth {
+            req = req.basic_auth(username, Some(password));
+        }
+
+        let response = req.send().await.map_err(CollectorError::HttpRequest)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(CollectorError::HttpStatus(status.as_u16()));
+        }
+
+        let body = response
+            .text()
+            .await
+            .map_err(CollectorError::HttpResponse)?;
+
+        parse_response(&body)
+    }
+
+    /// Bulk Read - 여러 MBean 일괄 조회
+    #[instrument(skip(self, mbeans), fields(count = mbeans.len()))]
+    pub async fn read_mbeans_bulk(
+        &self,
+        mbeans: &[(&str, Option<&[String]>)],
+    ) -> CollectResult<Vec<JolokiaResponse>> {
+        if mbeans.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let requests: Vec<JolokiaRequest> = mbeans
+            .iter()
+            .map(|(mbean, attrs)| JolokiaRequest {
+                request_type: "read".to_string(),
+                mbean: mbean.to_string(),
+                attribute: attrs.map(|a| {
+                    if a.len() == 1 {
+                        AttributeSpec::Single(a[0].clone())
+                    } else {
+                        AttributeSpec::Multiple(a.to_vec())
+                    }
+                }),
+            })
+            .collect();
+
+        debug!(
+            "Sending Jolokia bulk read request for {} mbeans",
+            requests.len()
+        );
+
+        let mut req = self.client.post(&self.base_url).json(&requests);
+
+        if let Some((username, password)) = &self.auth {
+            req = req.basic_auth(username, Some(password));
+        }
+
+        let response = req.send().await.map_err(CollectorError::HttpRequest)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(CollectorError::HttpStatus(status.as_u16()));
+        }
+
+        let body = response
+            .text()
+            .await
+            .map_err(CollectorError::HttpResponse)?;
+
+        parse_bulk_response(&body)
+    }
+
+    /// MBean 목록 조회 (Search)
+    #[instrument(skip(self))]
+    pub async fn search_mbeans(&self, pattern: &str) -> CollectResult<Vec<String>> {
+        #[derive(Serialize)]
+        struct SearchRequest {
+            #[serde(rename = "type")]
+            request_type: String,
+            mbean: String,
+        }
+
+        let request = SearchRequest {
+            request_type: "search".to_string(),
+            mbean: pattern.to_string(),
+        };
+
+        let mut req = self.client.post(&self.base_url).json(&request);
+
+        if let Some((username, password)) = &self.auth {
+            req = req.basic_auth(username, Some(password));
+        }
+
+        let response = req.send().await.map_err(CollectorError::HttpRequest)?;
+
+        let body = response
+            .text()
+            .await
+            .map_err(CollectorError::HttpResponse)?;
+
+        #[derive(Deserialize)]
+        struct SearchResponse {
+            value: Vec<String>,
+            status: u16,
+        }
+
+        let parsed: SearchResponse =
+            serde_json::from_str(&body).map_err(|e| CollectorError::JsonParse(e.to_string()))?;
+
+        if parsed.status != 200 {
+            return Err(CollectorError::JolokiaError {
+                status: parsed.status,
+                message: "Search failed".to_string(),
+            });
+        }
+
+        Ok(parsed.value)
+    }
+
+    /// 재시도 로직이 포함된 단일 MBean 조회
+    pub async fn read_mbean_with_retry(
+        &self,
+        mbean: &str,
+        attributes: Option<&[String]>,
+        config: &RetryConfig,
+    ) -> CollectResult<JolokiaResponse> {
+        let mut delay = config.initial_delay;
+        let mut last_error = None;
+
+        for attempt in 0..=config.max_retries {
+            match self.read_mbean(mbean, attributes).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    if !e.is_retryable() {
+                        return Err(e);
+                    }
+
+                    last_error = Some(e);
+
+                    if attempt < config.max_retries {
+                        warn!(
+                            attempt = attempt + 1,
+                            max = config.max_retries,
+                            delay_ms = delay.as_millis() as u64,
+                            "Request failed, retrying"
+                        );
+                        tokio::time::sleep(delay).await;
+                        delay = std::cmp::min(
+                            Duration::from_secs_f64(delay.as_secs_f64() * config.multiplier),
+                            config.max_delay,
+                        );
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or(CollectorError::MaxRetriesExceeded))
+    }
+
+    /// Fallback이 있는 수집 - 부분 실패 허용
+    pub async fn collect_with_fallback(
+        &self,
+        mbeans: &[String],
+    ) -> Vec<(String, CollectResult<JolokiaResponse>)> {
+        let mut results = Vec::new();
+
+        for mbean in mbeans {
+            let result = self.read_mbean(mbean, None).await;
+
+            match &result {
+                Ok(response) if response.status == 200 => {
+                    debug!(mbean = %mbean, "MBean collected successfully");
+                }
+                Ok(response) => {
+                    warn!(
+                        mbean = %mbean,
+                        status = response.status,
+                        error = ?response.error,
+                        "MBean collection returned non-200 status"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        mbean = %mbean,
+                        error = %e,
+                        "Failed to collect MBean"
+                    );
+                }
+            }
+
+            results.push((mbean.clone(), result));
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_new() {
+        let client = JolokiaClient::new("http://localhost:8778/jolokia", 5000);
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_client_with_auth() {
+        let client = JolokiaClient::new("http://localhost:8778/jolokia", 5000)
+            .unwrap()
+            .with_auth("user", "pass");
+        assert!(client.auth.is_some());
+    }
+
+    #[test]
+    fn test_retry_config_default() {
+        let config = RetryConfig::default();
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.initial_delay, Duration::from_millis(100));
+    }
+}

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,26 +1,78 @@
-//! JMX metrics collector module
+//! Jolokia JMX 메트릭 수집 모듈
 //!
-//! This module handles communication with Jolokia endpoints
-//! and parsing of JMX metric data.
+//! Java 애플리케이션의 Jolokia 엔드포인트에서 JMX 메트릭을 수집합니다.
 //!
-//! **Status: Stub** - Implementation in Phase 2
+//! # Example
+//!
+//! ```ignore
+//! use rjmx_exporter::collector::{JolokiaClient, CollectConfig};
+//!
+//! let client = JolokiaClient::new("http://localhost:8778/jolokia", 5000)?;
+//! let response = client.read_mbean("java.lang:type=Memory", None).await?;
+//! ```
 
-// Placeholder for Phase 2 implementation
-// pub mod client;
-// pub mod parser;
+mod client;
+mod parser;
 
-/// Placeholder struct for the JMX collector
-pub struct Collector;
+pub use client::{JolokiaClient, RetryConfig};
+pub use parser::{
+    parse_bulk_response, parse_response, AttributeValue, CollectResult, JolokiaResponse,
+    MBeanValue, ObjectName, RequestInfo,
+};
 
-impl Collector {
-    /// Create a new collector (stub)
-    pub fn new() -> Self {
-        Self
+/// MBean 수집 설정
+#[derive(Debug, Clone)]
+pub struct CollectConfig {
+    /// 조회할 MBean ObjectName 목록
+    pub mbeans: Vec<String>,
+    /// 특정 속성만 조회 (None이면 전체)
+    pub attributes: Option<Vec<String>>,
+    /// 요청 타임아웃 (밀리초)
+    pub timeout_ms: u64,
+}
+
+impl Default for CollectConfig {
+    fn default() -> Self {
+        Self {
+            mbeans: vec![],
+            attributes: None,
+            timeout_ms: 5000,
+        }
     }
 }
 
-impl Default for Collector {
-    fn default() -> Self {
-        Self::new()
+/// Collector 구조체 - 설정 기반 수집 래퍼
+pub struct Collector {
+    client: JolokiaClient,
+    config: CollectConfig,
+}
+
+impl Collector {
+    /// 새 Collector 생성
+    pub fn new(base_url: &str, config: CollectConfig) -> CollectResult<Self> {
+        let client = JolokiaClient::new(base_url, config.timeout_ms)?;
+        Ok(Self { client, config })
+    }
+
+    /// 설정된 MBean들 수집
+    pub async fn collect(&self) -> Vec<(String, CollectResult<JolokiaResponse>)> {
+        self.client.collect_with_fallback(&self.config.mbeans).await
+    }
+
+    /// Bulk 수집 (단일 HTTP 요청)
+    pub async fn collect_bulk(&self) -> CollectResult<Vec<JolokiaResponse>> {
+        let mbeans: Vec<(&str, Option<&[String]>)> = self
+            .config
+            .mbeans
+            .iter()
+            .map(|m| (m.as_str(), self.config.attributes.as_deref()))
+            .collect();
+
+        self.client.read_mbeans_bulk(&mbeans).await
+    }
+
+    /// 클라이언트 참조 반환
+    pub fn client(&self) -> &JolokiaClient {
+        &self.client
     }
 }

--- a/src/collector/parser.rs
+++ b/src/collector/parser.rs
@@ -1,0 +1,493 @@
+//! Jolokia JSON 응답 파서
+//!
+//! Jolokia API 응답을 파싱하여 내부 데이터 구조로 변환합니다.
+
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::error::CollectorError;
+
+/// Collector 작업 결과 타입
+pub type CollectResult<T> = Result<T, CollectorError>;
+
+/// Jolokia API 응답 구조체
+#[derive(Debug, Clone)]
+pub struct JolokiaResponse {
+    /// 요청 정보
+    pub request: RequestInfo,
+    /// 응답 값
+    pub value: MBeanValue,
+    /// 응답 상태 코드
+    pub status: u16,
+    /// 타임스탬프 (Unix epoch)
+    pub timestamp: u64,
+    /// 에러 메시지 (실패 시)
+    pub error: Option<String>,
+    /// 에러 타입 (실패 시)
+    pub error_type: Option<String>,
+}
+
+/// 요청 정보
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequestInfo {
+    /// MBean ObjectName
+    pub mbean: String,
+    /// 조회한 속성 (단일 또는 복수)
+    #[serde(default)]
+    pub attribute: Option<Value>,
+    /// 요청 타입
+    #[serde(rename = "type")]
+    pub request_type: String,
+}
+
+/// MBean 값 - 다양한 형태를 지원
+#[derive(Debug, Clone)]
+pub enum MBeanValue {
+    /// 단순 숫자 값
+    Number(f64),
+    /// 문자열 값
+    String(String),
+    /// 불리언 값
+    Boolean(bool),
+    /// Null 값
+    Null,
+    /// 복합 객체 (CompositeData)
+    Composite(HashMap<String, AttributeValue>),
+    /// 배열
+    Array(Vec<AttributeValue>),
+    /// 와일드카드 결과 (MBean ObjectName -> 속성 맵)
+    Wildcard(HashMap<String, HashMap<String, AttributeValue>>),
+}
+
+/// 개별 속성 값
+#[derive(Debug, Clone)]
+pub enum AttributeValue {
+    /// 정수
+    Integer(i64),
+    /// 실수
+    Float(f64),
+    /// 문자열
+    String(String),
+    /// 불리언
+    Boolean(bool),
+    /// Null
+    Null,
+    /// 중첩 객체
+    Object(HashMap<String, AttributeValue>),
+    /// 배열
+    Array(Vec<AttributeValue>),
+}
+
+impl AttributeValue {
+    /// 숫자로 변환 시도
+    ///
+    /// # Precision Warning
+    /// When converting `Integer(i64)` to `f64`, precision loss may occur
+    /// for values > 2^53 (9,007,199,254,740,992).
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            AttributeValue::Integer(i) => {
+                if i.abs() > (1i64 << 53) {
+                    tracing::warn!(
+                        value = i,
+                        "Large integer may lose precision when converted to f64"
+                    );
+                }
+                Some(*i as f64)
+            }
+            AttributeValue::Float(f) => Some(*f),
+            AttributeValue::String(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+
+    /// 문자열로 변환
+    pub fn as_string(&self) -> Option<String> {
+        match self {
+            AttributeValue::String(s) => Some(s.clone()),
+            AttributeValue::Integer(i) => Some(i.to_string()),
+            AttributeValue::Float(f) => Some(f.to_string()),
+            AttributeValue::Boolean(b) => Some(b.to_string()),
+            _ => None,
+        }
+    }
+}
+
+/// 단일 응답 파싱
+pub fn parse_response(json: &str) -> CollectResult<JolokiaResponse> {
+    let raw: RawJolokiaResponse =
+        serde_json::from_str(json).map_err(|e| CollectorError::JsonParse(e.to_string()))?;
+
+    convert_raw_response(raw)
+}
+
+/// Bulk 응답 파싱
+pub fn parse_bulk_response(json: &str) -> CollectResult<Vec<JolokiaResponse>> {
+    let raw_responses: Vec<RawJolokiaResponse> =
+        serde_json::from_str(json).map_err(|e| CollectorError::JsonParse(e.to_string()))?;
+
+    raw_responses
+        .into_iter()
+        .map(convert_raw_response)
+        .collect()
+}
+
+/// 내부 파싱용 구조체
+#[derive(Deserialize)]
+struct RawJolokiaResponse {
+    request: RequestInfo,
+    value: Option<Value>,
+    status: u16,
+    #[serde(default)]
+    timestamp: u64,
+    error: Option<String>,
+    error_type: Option<String>,
+}
+
+fn convert_raw_response(raw: RawJolokiaResponse) -> CollectResult<JolokiaResponse> {
+    // 에러 응답 처리
+    if raw.status != 200 {
+        return Ok(JolokiaResponse {
+            request: raw.request,
+            value: MBeanValue::Null,
+            status: raw.status,
+            timestamp: raw.timestamp,
+            error: raw.error,
+            error_type: raw.error_type,
+        });
+    }
+
+    let value = match raw.value {
+        Some(v) => parse_mbean_value(v)?,
+        None => MBeanValue::Null,
+    };
+
+    Ok(JolokiaResponse {
+        request: raw.request,
+        value,
+        status: raw.status,
+        timestamp: raw.timestamp,
+        error: raw.error,
+        error_type: raw.error_type,
+    })
+}
+
+fn parse_mbean_value(value: Value) -> CollectResult<MBeanValue> {
+    match value {
+        Value::Null => Ok(MBeanValue::Null),
+        Value::Bool(b) => Ok(MBeanValue::Boolean(b)),
+        Value::Number(n) => Ok(MBeanValue::Number(n.as_f64().unwrap_or(0.0))),
+        Value::String(s) => Ok(MBeanValue::String(s)),
+        Value::Array(arr) => {
+            let parsed: Vec<AttributeValue> = arr
+                .into_iter()
+                .map(parse_attribute_value)
+                .collect::<CollectResult<_>>()?;
+            Ok(MBeanValue::Array(parsed))
+        }
+        Value::Object(map) => {
+            // 와일드카드 응답인지 확인 (값이 모두 객체이고 MBean ObjectName 형태)
+            let is_wildcard = map
+                .iter()
+                .all(|(k, v)| k.contains(':') && k.contains('=') && v.is_object());
+
+            if is_wildcard && !map.is_empty() {
+                let mut result = HashMap::new();
+                for (mbean_name, attrs) in map {
+                    if let Value::Object(attr_map) = attrs {
+                        let parsed_attrs: HashMap<String, AttributeValue> = attr_map
+                            .into_iter()
+                            .map(|(k, v)| Ok((k, parse_attribute_value(v)?)))
+                            .collect::<CollectResult<_>>()?;
+                        result.insert(mbean_name, parsed_attrs);
+                    }
+                }
+                Ok(MBeanValue::Wildcard(result))
+            } else {
+                // 일반 CompositeData
+                let parsed: HashMap<String, AttributeValue> = map
+                    .into_iter()
+                    .map(|(k, v)| Ok((k, parse_attribute_value(v)?)))
+                    .collect::<CollectResult<_>>()?;
+                Ok(MBeanValue::Composite(parsed))
+            }
+        }
+    }
+}
+
+fn parse_attribute_value(value: Value) -> CollectResult<AttributeValue> {
+    match value {
+        Value::Null => Ok(AttributeValue::Null),
+        Value::Bool(b) => Ok(AttributeValue::Boolean(b)),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(AttributeValue::Integer(i))
+            } else {
+                Ok(AttributeValue::Float(n.as_f64().unwrap_or(0.0)))
+            }
+        }
+        Value::String(s) => Ok(AttributeValue::String(s)),
+        Value::Array(arr) => {
+            let parsed: Vec<AttributeValue> = arr
+                .into_iter()
+                .map(parse_attribute_value)
+                .collect::<CollectResult<_>>()?;
+            Ok(AttributeValue::Array(parsed))
+        }
+        Value::Object(map) => {
+            let parsed: HashMap<String, AttributeValue> = map
+                .into_iter()
+                .map(|(k, v)| Ok((k, parse_attribute_value(v)?)))
+                .collect::<CollectResult<_>>()?;
+            Ok(AttributeValue::Object(parsed))
+        }
+    }
+}
+
+/// 값 추출 유틸리티 - Prometheus 메트릭용
+impl MBeanValue {
+    /// Composite 값에서 특정 키의 숫자 추출
+    pub fn get_composite_number(&self, key: &str) -> Option<f64> {
+        match self {
+            MBeanValue::Composite(map) => map.get(key).and_then(|v| v.as_f64()),
+            _ => None,
+        }
+    }
+
+    /// 단순 숫자 값 추출
+    pub fn as_number(&self) -> Option<f64> {
+        match self {
+            MBeanValue::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// 모든 숫자 값을 (이름, 값) 쌍으로 평탄화
+    pub fn flatten_numbers(&self) -> Vec<(String, f64)> {
+        let mut result = Vec::new();
+        self.flatten_numbers_inner("", &mut result);
+        result
+    }
+
+    fn flatten_numbers_inner(&self, prefix: &str, result: &mut Vec<(String, f64)>) {
+        match self {
+            MBeanValue::Number(n) => {
+                let name = if prefix.is_empty() {
+                    "value".to_string()
+                } else {
+                    prefix.to_string()
+                };
+                result.push((name, *n));
+            }
+            MBeanValue::Composite(map) => {
+                for (key, value) in map {
+                    let new_prefix = if prefix.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{}_{}", prefix, key)
+                    };
+                    if let Some(n) = value.as_f64() {
+                        result.push((new_prefix, n));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// MBean ObjectName 구조
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectName {
+    /// 도메인 (예: "java.lang")
+    pub domain: String,
+    /// 속성 (예: {"type": "Memory"})
+    pub properties: HashMap<String, String>,
+}
+
+impl ObjectName {
+    /// ObjectName 문자열 파싱
+    ///
+    /// # Limitations
+    /// - Quoted keys/values are NOT fully supported
+    pub fn parse(s: &str) -> CollectResult<Self> {
+        let parts: Vec<&str> = s.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return Err(CollectorError::InvalidObjectName(s.to_string()));
+        }
+
+        let domain = parts[0].to_string();
+        let mut properties = HashMap::new();
+
+        for prop in parts[1].split(',') {
+            let kv: Vec<&str> = prop.splitn(2, '=').collect();
+            if kv.len() == 2 {
+                properties.insert(kv[0].to_string(), kv[1].to_string());
+            }
+        }
+
+        Ok(Self { domain, properties })
+    }
+
+    /// Prometheus 라벨용 문자열 생성
+    pub fn to_label_string(&self) -> String {
+        let props: Vec<String> = self
+            .properties
+            .iter()
+            .map(|(k, v)| format!("{}=\"{}\"", k, v))
+            .collect();
+        format!("{}:{}", self.domain, props.join(","))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_number_response() {
+        let json = r#"{
+            "request": {
+                "mbean": "java.lang:type=Threading",
+                "attribute": "ThreadCount",
+                "type": "read"
+            },
+            "value": 42,
+            "timestamp": 1609459200,
+            "status": 200
+        }"#;
+
+        let response = parse_response(json).unwrap();
+        assert_eq!(response.status, 200);
+        assert!(matches!(response.value, MBeanValue::Number(n) if (n - 42.0).abs() < f64::EPSILON));
+    }
+
+    #[test]
+    fn test_parse_composite_response() {
+        let json = r#"{
+            "request": {
+                "mbean": "java.lang:type=Memory",
+                "attribute": "HeapMemoryUsage",
+                "type": "read"
+            },
+            "value": {
+                "init": 268435456,
+                "committed": 268435456,
+                "max": 4294967296,
+                "used": 52428800
+            },
+            "timestamp": 1609459200,
+            "status": 200
+        }"#;
+
+        let response = parse_response(json).unwrap();
+        assert_eq!(response.status, 200);
+
+        if let MBeanValue::Composite(map) = &response.value {
+            assert_eq!(map.get("used").and_then(|v| v.as_f64()), Some(52428800.0));
+            assert_eq!(map.get("max").and_then(|v| v.as_f64()), Some(4294967296.0));
+        } else {
+            panic!("Expected Composite value");
+        }
+    }
+
+    #[test]
+    fn test_parse_error_response() {
+        let json = r#"{
+            "request": {
+                "mbean": "invalid:type=NotFound",
+                "type": "read"
+            },
+            "error_type": "javax.management.InstanceNotFoundException",
+            "error": "No MBean found",
+            "status": 404
+        }"#;
+
+        let response = parse_response(json).unwrap();
+        assert_eq!(response.status, 404);
+        assert!(response.error.is_some());
+        assert_eq!(
+            response.error_type,
+            Some("javax.management.InstanceNotFoundException".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_bulk_response() {
+        let json = r#"[
+            {
+                "request": {"mbean": "java.lang:type=Threading", "type": "read"},
+                "value": 42,
+                "status": 200,
+                "timestamp": 1609459200
+            },
+            {
+                "request": {"mbean": "java.lang:type=Memory", "type": "read"},
+                "value": {"used": 1000000},
+                "status": 200,
+                "timestamp": 1609459200
+            }
+        ]"#;
+
+        let responses = parse_bulk_response(json).unwrap();
+        assert_eq!(responses.len(), 2);
+        assert_eq!(responses[0].status, 200);
+        assert_eq!(responses[1].status, 200);
+    }
+
+    #[test]
+    fn test_parse_wildcard_response() {
+        let json = r#"{
+            "request": {
+                "mbean": "java.lang:type=GarbageCollector,name=*",
+                "type": "read"
+            },
+            "value": {
+                "java.lang:type=GarbageCollector,name=G1 Young Generation": {
+                    "CollectionCount": 42,
+                    "CollectionTime": 1234
+                },
+                "java.lang:type=GarbageCollector,name=G1 Old Generation": {
+                    "CollectionCount": 5,
+                    "CollectionTime": 567
+                }
+            },
+            "timestamp": 1609459200,
+            "status": 200
+        }"#;
+
+        let response = parse_response(json).unwrap();
+        if let MBeanValue::Wildcard(map) = &response.value {
+            assert_eq!(map.len(), 2);
+            assert!(map.contains_key("java.lang:type=GarbageCollector,name=G1 Young Generation"));
+        } else {
+            panic!("Expected Wildcard value");
+        }
+    }
+
+    #[test]
+    fn test_object_name_parse() {
+        let name = ObjectName::parse("java.lang:type=Memory").unwrap();
+        assert_eq!(name.domain, "java.lang");
+        assert_eq!(name.properties.get("type"), Some(&"Memory".to_string()));
+
+        let name2 = ObjectName::parse("java.lang:type=GarbageCollector,name=G1").unwrap();
+        assert_eq!(name2.properties.get("name"), Some(&"G1".to_string()));
+    }
+
+    #[test]
+    fn test_flatten_numbers() {
+        let value = MBeanValue::Composite(HashMap::from([
+            ("used".to_string(), AttributeValue::Integer(1000)),
+            ("max".to_string(), AttributeValue::Integer(2000)),
+            (
+                "name".to_string(),
+                AttributeValue::String("test".to_string()),
+            ),
+        ]));
+
+        let flattened = value.flatten_numbers();
+        assert_eq!(flattened.len(), 2);
+    }
+}

--- a/tests/collector_integration.rs
+++ b/tests/collector_integration.rs
@@ -1,0 +1,186 @@
+//! Collector 통합 테스트
+//!
+//! wiremock을 사용한 HTTP 모킹 테스트
+
+use rjmx_exporter::collector::{JolokiaClient, MBeanValue};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_read_mbean_success() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/jolokia"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "request": {
+                "mbean": "java.lang:type=Memory",
+                "type": "read"
+            },
+            "value": {
+                "HeapMemoryUsage": {
+                    "used": 52428800_i64,
+                    "max": 4294967296_i64
+                }
+            },
+            "timestamp": 1609459200,
+            "status": 200
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/jolokia", mock_server.uri());
+    let client = JolokiaClient::new(&url, 5000).unwrap();
+    let response = client
+        .read_mbean("java.lang:type=Memory", None)
+        .await
+        .unwrap();
+
+    assert_eq!(response.status, 200);
+    assert!(matches!(response.value, MBeanValue::Composite(_)));
+}
+
+#[tokio::test]
+async fn test_bulk_read() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/jolokia"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "request": {"mbean": "java.lang:type=Threading", "type": "read"},
+                "value": 42,
+                "status": 200,
+                "timestamp": 1609459200
+            },
+            {
+                "request": {"mbean": "java.lang:type=Memory", "type": "read"},
+                "value": {"used": 1000000},
+                "status": 200,
+                "timestamp": 1609459200
+            }
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/jolokia", mock_server.uri());
+    let client = JolokiaClient::new(&url, 5000).unwrap();
+    let responses = client
+        .read_mbeans_bulk(&[
+            ("java.lang:type=Threading", None),
+            ("java.lang:type=Memory", None),
+        ])
+        .await
+        .unwrap();
+
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0].status, 200);
+    assert_eq!(responses[1].status, 200);
+}
+
+#[tokio::test]
+async fn test_timeout_handling() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(10)))
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/jolokia", mock_server.uri());
+    let client = JolokiaClient::new(&url, 100).unwrap();
+    let result = client.read_mbean("java.lang:type=Memory", None).await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_error_response_handling() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "request": {"mbean": "invalid:type=NotFound", "type": "read"},
+            "error_type": "javax.management.InstanceNotFoundException",
+            "error": "No MBean found",
+            "status": 404
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/jolokia", mock_server.uri());
+    let client = JolokiaClient::new(&url, 5000).unwrap();
+    let response = client
+        .read_mbean("invalid:type=NotFound", None)
+        .await
+        .unwrap();
+
+    assert_eq!(response.status, 404);
+    assert!(response.error.is_some());
+}
+
+#[tokio::test]
+async fn test_connection_pool_reuse() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "request": {"mbean": "test:type=Test", "type": "read"},
+            "value": 1,
+            "status": 200,
+            "timestamp": 1609459200
+        })))
+        .expect(10)
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/jolokia", mock_server.uri());
+    let client = JolokiaClient::new(&url, 5000).unwrap();
+
+    for _ in 0..10 {
+        let result = client.read_mbean("test:type=Test", None).await;
+        assert!(result.is_ok());
+    }
+}
+
+#[tokio::test]
+async fn test_search_mbeans() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "value": [
+                "java.lang:type=GarbageCollector,name=G1 Young Generation",
+                "java.lang:type=GarbageCollector,name=G1 Old Generation"
+            ],
+            "status": 200
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/jolokia", mock_server.uri());
+    let client = JolokiaClient::new(&url, 5000).unwrap();
+    let mbeans = client
+        .search_mbeans("java.lang:type=GarbageCollector,*")
+        .await
+        .unwrap();
+
+    assert_eq!(mbeans.len(), 2);
+}
+
+#[tokio::test]
+async fn test_http_500_error() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock_server)
+        .await;
+
+    let url = format!("{}/jolokia", mock_server.uri());
+    let client = JolokiaClient::new(&url, 5000).unwrap();
+    let result = client.read_mbean("java.lang:type=Memory", None).await;
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- Jolokia HTTP 클라이언트 구현 (reqwest 기반)
- JSON 응답 파싱 및 데이터 구조 정의
- 통합 테스트 (wiremock) 및 벤치마크 추가

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `Cargo.toml` | wiremock, criterion 의존성 추가 |
| `src/collector/client.rs` | JolokiaClient HTTP 클라이언트 구현 |
| `src/collector/parser.rs` | JSON 파싱 및 데이터 구조 (MBeanValue, AttributeValue) |
| `src/collector/mod.rs` | 모듈 공개 인터페이스, Collector 래퍼 |
| `src/error.rs` | CollectorError 에러 타입 추가 |
| `tests/collector_integration.rs` | wiremock 기반 통합 테스트 7개 |
| `benches/collector_bench.rs` | JSON 파싱 벤치마크 |

## 구현된 기능

| 기능 | 상태 | 설명 |
|------|------|------|
| read_mbean() | ✅ | 단일 MBean 조회 |
| read_mbeans_bulk() | ✅ | 여러 MBean 일괄 조회 |
| search_mbeans() | ✅ | MBean 패턴 검색 |
| Basic Auth | ✅ | 인증 지원 |
| Connection Pool | ✅ | reqwest 기본 풀 사용 |
| Retry Logic | ✅ | 지수 백오프 재시도 |
| Composite 파싱 | ✅ | HeapMemoryUsage 등 |
| Wildcard 파싱 | ✅ | GarbageCollector,name=* |

## 에러 타입

| 에러 | 재시도 가능 | 설명 |
|------|-------------|------|
| HttpRequest | ✅ | HTTP 요청 실패 |
| HttpResponse | ✅ | 응답 읽기 실패 |
| HttpStatus(5xx) | ✅ | 서버 에러 |
| Timeout | ✅ | 타임아웃 |
| ConnectionFailed | ✅ | 연결 실패 |
| JsonParse | ❌ | JSON 파싱 실패 |
| JolokiaError | ❌ | Jolokia 에러 응답 |

## Test plan
- [x] `cargo build` 성공
- [x] `cargo test` 19개 테스트 통과 (12 단위 + 7 통합)
- [x] `cargo clippy -- -D warnings` 경고 없음
- [x] `cargo fmt -- --check` 통과

## 다음 단계
Phase 3: Transformer 구현 (MBean → Prometheus 메트릭 변환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)